### PR TITLE
v3.4.0: Generation & Decryption fixes

### DIFF
--- a/Scanbot.SDK.Example.Forms.Android/Scanbot.SDK.Example.Forms.Android.csproj
+++ b/Scanbot.SDK.Example.Forms.Android/Scanbot.SDK.Example.Forms.Android.csproj
@@ -66,7 +66,7 @@
       <Version>1.7.335</Version>
     </PackageReference>
     <PackageReference Include="ScanbotSDK.Xamarin.Forms">
-      <Version>3.3.1</Version>
+      <Version>3.4.0-beta4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Scanbot.SDK.Example.Forms.Android/Scanbot.SDK.Example.Forms.Android.csproj
+++ b/Scanbot.SDK.Example.Forms.Android/Scanbot.SDK.Example.Forms.Android.csproj
@@ -66,7 +66,7 @@
       <Version>1.7.335</Version>
     </PackageReference>
     <PackageReference Include="ScanbotSDK.Xamarin.Forms">
-      <Version>3.4.0-beta4</Version>
+      <Version>3.4.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Scanbot.SDK.Example.Forms.iOS/Scanbot.SDK.Example.Forms.iOS.csproj
+++ b/Scanbot.SDK.Example.Forms.iOS/Scanbot.SDK.Example.Forms.iOS.csproj
@@ -145,7 +145,7 @@
       <Version>1.7.335</Version>
     </PackageReference>
     <PackageReference Include="ScanbotSDK.Xamarin.Forms">
-      <Version>3.4.0-beta4</Version>
+      <Version>3.4.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Scanbot.SDK.Example.Forms.iOS/Scanbot.SDK.Example.Forms.iOS.csproj
+++ b/Scanbot.SDK.Example.Forms.iOS/Scanbot.SDK.Example.Forms.iOS.csproj
@@ -145,7 +145,7 @@
       <Version>1.7.335</Version>
     </PackageReference>
     <PackageReference Include="ScanbotSDK.Xamarin.Forms">
-      <Version>3.3.1</Version>
+      <Version>3.4.0-beta4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Scanbot.SDK.Example.Forms/MainPage.cs
+++ b/Scanbot.SDK.Example.Forms/MainPage.cs
@@ -91,6 +91,7 @@ namespace Scanbot.SDK.Example.Forms
                     // If encryption is enabled, load the decrypted document.
                     // Else accessible via page.Document
                     var blur = await SBSDK.Operations.EstimateBlurriness(await page.DecryptedDocument());
+                    //var blur = await SBSDK.Operations.EstimateBlurriness(page.Document);
                     Console.WriteLine("Estimated blurriness for detected document: " + blur);
                 }
 

--- a/Scanbot.SDK.Example.Forms/Pages/ImageDetailPage.cs
+++ b/Scanbot.SDK.Example.Forms/Pages/ImageDetailPage.cs
@@ -46,6 +46,7 @@ namespace Scanbot.SDK.Example.Forms
             // If encryption is enabled, load the decrypted document.
             // Else accessible via Document or DocumentPreview
             Image.Source = await Pages.Instance.SelectedPage.DecryptedDocument();
+            //Image.Source = Pages.Instance.SelectedPage.Document;
         }
 
         async void OnCropButtonClick(object sender, EventArgs e)

--- a/Scanbot.SDK.Example.Forms/Subviews/Cells/ImageResultCell.cs
+++ b/Scanbot.SDK.Example.Forms/Subviews/Cells/ImageResultCell.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
+﻿
 using ScanbotSDK.Xamarin.Forms;
 using Xamarin.Forms;
 
@@ -33,8 +31,8 @@ namespace Scanbot.SDK.Example.Forms
             Source = (IScannedPage)BindingContext;
             // If encryption is enabled, load the decrypted document.
             // Else accessible via page.Document
-            Document.Source = await Source.DecryptedDocument();
-
+            Document.Source = await Source.DecryptedDocumentPreview();
+            //Document.Source = Source.DocumentPreview;
             base.OnBindingContextChanged();
         }
 


### PR DESCRIPTION
Apologies, the branch name is confusing. 

Release notes:

```
#### ScanbotSDK.Xamarin - Version 3.4.0 (7 May 2021)
- 🚀 Improvements:
  * Droid: Improved `ImageSource` loading performance
  * Droid: Preview generation fix
  * Functions to decrypt preview images: `await DecryptedOriginalPreview` & `await DecryptedDocumentPreview`
- 🚙 Under the hood:
  * Upgraded `ScanbotSDK.Xamarin` to v3.4.0
```