### PR TITLE
Epic 3538 - Bug native renderer app freeze and BarcodeImageGenerationType for CapturedImage

### DIFF
--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Native.Renderers.Example.Forms.iOS.csproj
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Native.Renderers.Example.Forms.iOS.csproj
@@ -74,8 +74,9 @@
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Renderers\IOSBarcodeCameraRenderer.cs" />
-    <Compile Include="Utils\ViewUtils.cs" />
+    <Compile Include="Renderers\Extensions.cs" />
     <Compile Include="Delegates\BarcodeScannerDelegates.cs" />
+    <Compile Include="Utils\ViewUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Renderers/BarcodeScannerDelegates.cs
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Renderers/BarcodeScannerDelegates.cs
@@ -1,8 +1,7 @@
-﻿using Native.Renderers.Example.Forms.iOS.Utils;
+﻿using Foundation;
 using ScanbotSDK.iOS;
-using ScanbotSDK.Xamarin.Forms;
 
-namespace Native.Renderers.Example.Forms.iOS
+namespace Native.Renderers.Example.Forms.iOS.Renderers
 {
     // Since we cannot directly inherit from SBSDKBarcodeScannerViewControllerDelegate in our ViewRenderer,
     // we have created this wrapper class to allow binding to its events through the use of delegates
@@ -23,25 +22,19 @@ namespace Native.Renderers.Example.Forms.iOS
 
         public override bool ShouldDetectBarcodes(SBSDKBarcodeScannerViewController controller)
         {
-            if (!SBSDK.IsLicenseValid)
-            {
-                ViewUtils.ShowAlert("License Expired!", "Ok");
-                return false;
-            }
-
             return isScanning;
         }
     }
 
-    internal class BarcodeTrackingOverlayDelegate : SBSDKBarcodeTrackingOverlayControllerDelegate
+    class BarcodeTrackingOverlayDelegate : SBSDKBarcodeTrackingOverlayControllerDelegate
     {
         public delegate void DidTapOnBarcodeAROverlay(SBSDKBarcodeScannerResult barcode);
         public DidTapOnBarcodeAROverlay DidTapBarcodeOverlay;
 
+        [Export("barcodeTrackingOverlay:didTapOnBarcode:")]
         public override void DidTapOnBarcode(SBSDKBarcodeTrackingOverlayController controller, SBSDKBarcodeScannerResult barcode)
         {
             DidTapBarcodeOverlay?.Invoke(barcode);
         }
     }
 }
-

--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Renderers/Extensions.cs
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Renderers/Extensions.cs
@@ -1,0 +1,36 @@
+﻿using ScanbotSDK.iOS;
+using ScanbotSDK.Xamarin.Forms;
+
+namespace Native.Renderers.Example.Forms.iOS.Renderers
+{
+    public static class Extension
+    {
+        public static SBSDKBarcodeOverlayFormat ToNative(this OverlayFormat overlayTextFormat)
+        {
+            switch (overlayTextFormat)
+            {
+                case OverlayFormat.None:
+                    return SBSDKBarcodeOverlayFormat.None;
+                case OverlayFormat.Code:
+                    return SBSDKBarcodeOverlayFormat.Code;
+                default:
+                    return SBSDKBarcodeOverlayFormat.CodeAndType;
+            }
+        }
+
+        public static SBSDKBarcodeImageGenerationType ToNative(this BarcodeImageGenerationType imageGenerationType)
+        {
+            switch (imageGenerationType)
+            {
+                case BarcodeImageGenerationType.None:
+                    return SBSDKBarcodeImageGenerationType.None;
+                case BarcodeImageGenerationType.CapturedImage:
+                    return SBSDKBarcodeImageGenerationType.CapturedImage;
+                case BarcodeImageGenerationType.FromVideoFrame:
+                    return SBSDKBarcodeImageGenerationType.FromVideoFrame;
+                default:
+                    return SBSDKBarcodeImageGenerationType.None;
+            }
+        }
+    }
+}

--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Renderers/IOSBarcodeCameraRenderer.cs
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms.iOS/Renderers/IOSBarcodeCameraRenderer.cs
@@ -1,13 +1,16 @@
-﻿using System;
+﻿using CoreGraphics;
+
 using System.Linq;
-using CoreGraphics;
-using HomeKit;
+
 using Native.Renderers.Example.Forms.iOS.Renderers;
 using Native.Renderers.Example.Forms.Views;
+
 using ScanbotSDK.iOS;
 using ScanbotSDK.Xamarin.Forms;
 using ScanbotSDK.Xamarin.Forms.iOS;
+
 using UIKit;
+
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.iOS;
 
@@ -83,34 +86,12 @@ namespace Native.Renderers.Example.Forms.iOS.Renderers
         }
     }
 
-    // Since we cannot directly inherit from SBSDKBarcodeScannerViewControllerDelegate in our ViewRenderer,
-    // we have created this wrapper class to allow binding to its events through the use of delegates
-    class BarcodeScannerDelegate : SBSDKBarcodeScannerViewControllerDelegate
-    {
-        internal bool isScanning = true;
-        public delegate void OnDetectHandler(SBSDKBarcodeScannerResult[] codes);
-        public OnDetectHandler OnDetect;
-
-        public override void DidDetectBarcodes(SBSDKBarcodeScannerViewController controller, SBSDKBarcodeScannerResult[] codes)
-        {
-            if (controller.BarcodeImageGenerationType == SBSDKBarcodeImageGenerationType.CapturedImage)
-            {
-                isScanning = false; // it will restrict further scans and stop scanning when the image is captured.
-            }
-            OnDetect?.Invoke(codes);
-        }
-
-        public override bool ShouldDetectBarcodes(SBSDKBarcodeScannerViewController controller)
-        {
-            return isScanning;
-        }
-    }
-
     class IOSBarcodeCameraView : UIView
     {
         public bool initialised = false;
         public SBSDKBarcodeScannerViewController Controller { get; private set; }
-        internal BarcodeScannerDelegate ScannerDelegate;
+        public BarcodeScannerDelegate ScannerDelegate { get; private set; }
+        internal bool IsInitialised = false;
         private BarcodeCameraView element;
         public IOSBarcodeCameraView(CGRect frame) : base(frame) { }
 
@@ -154,6 +135,7 @@ namespace Native.Renderers.Example.Forms.iOS.Renderers
                 textStyle.TextBackgroundSelectedColor = configuration.HighlightedTextContainerColor?.ToUIColor();
 
                 overlayConfiguration.IsAutomaticSelectionEnabled = configuration.AutomaticSelectionEnabled;
+                overlayConfiguration.IsSelectable = true;
                 overlayConfiguration.TextStyle = textStyle;
                 overlayConfiguration.PolygonStyle = polygonStyle;
 
@@ -190,37 +172,6 @@ namespace Native.Renderers.Example.Forms.iOS.Renderers
             {
                 Barcodes = new System.Collections.Generic.List<Barcode> { barcode.ToFormsBarcode() }
             });
-        }
-    }
-
-    public static class Extension
-    {
-        public static SBSDKBarcodeOverlayFormat ToNative(this OverlayFormat overlayTextFormat)
-        {
-            switch (overlayTextFormat)
-            {
-                case OverlayFormat.None:
-                    return SBSDKBarcodeOverlayFormat.None;
-                case OverlayFormat.Code:
-                    return SBSDKBarcodeOverlayFormat.Code;
-                default:
-                    return SBSDKBarcodeOverlayFormat.CodeAndType;
-            }
-        }
-
-        public static SBSDKBarcodeImageGenerationType ToNative(this BarcodeImageGenerationType imageGenerationType)
-        {
-            switch (imageGenerationType)
-            {
-                case BarcodeImageGenerationType.None:
-                    return SBSDKBarcodeImageGenerationType.None;
-                case BarcodeImageGenerationType.CapturedImage:
-                    return SBSDKBarcodeImageGenerationType.CapturedImage;
-                case BarcodeImageGenerationType.FromVideoFrame:
-                    return SBSDKBarcodeImageGenerationType.FromVideoFrame;
-                default:
-                    return SBSDKBarcodeImageGenerationType.None;
-            }
         }
     }
 }

--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/MainPage.xaml
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/MainPage.xaml
@@ -6,36 +6,37 @@
              ios:Page.UseSafeArea="true"
              BackgroundColor="#c8193c"
              x:Class="Native.Renderers.Example.Forms.MainPage">
-    
-    <StackLayout BackgroundColor="#e2e2e2" Spacing="0">
-        <Frame BackgroundColor="#c8193c" Padding="16" CornerRadius="0" HasShadow="False">
-            <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
-                <Label Text="Barcode Scanner Example" VerticalOptions="Center" HorizontalTextAlignment="Start" TextColor="White" FontSize="18"/>
-                <ImageButton x:Name="infoButton" Source="ic_info.png" HorizontalOptions="EndAndExpand" VerticalOptions="Center" BackgroundColor="Transparent" WidthRequest="24" HeightRequest="24"/>
-            </StackLayout>
-        </Frame>
+    <ScrollView>
+        <StackLayout BackgroundColor="#e2e2e2" Spacing="0">
+            <Frame BackgroundColor="#c8193c" Padding="16" CornerRadius="0" HasShadow="False">
+                <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+                    <Label Text="Barcode Scanner Example" VerticalOptions="Center" HorizontalTextAlignment="Start" TextColor="White" FontSize="18"/>
+                    <ImageButton x:Name="infoButton" Source="ic_info.png" HorizontalOptions="EndAndExpand" VerticalOptions="Center" BackgroundColor="Transparent" WidthRequest="24" HeightRequest="24"/>
+                </StackLayout>
+            </Frame>
 
-        <!-- =============================================================================================================
+            <!-- =============================================================================================================
 
         Here we include our BarcodeCameraView. This view will be overriden by our native implementation because of
         the custom renderers that we have created. See: BarcodeCameraView.cs and AndroidBarcodeCameraRenderer.cs.
         Remember to define an xmlns attribute on the XAML root element to access your Views (in this case xmlns:local) -->
+            <Grid>
+                <Image x:Name="cameraViewImage" HeightRequest="250" BackgroundColor="WhiteSmoke"/>
+                <local:BarcodeCameraView x:Name="cameraView" HeightRequest="250" BackgroundColor="#1f1f1f"/>
+            </Grid>
+            <!--==========================================================================================================-->
 
-        <local:BarcodeCameraView x:Name="cameraView" HeightRequest="250" BackgroundColor="#1f1f1f"/>
-       
-        <!--==========================================================================================================-->
-
-        <StackLayout x:Name="buttonsLayout">
-            <BoxView Style="{StaticResource Separator}"/>
+            <StackLayout x:Name="buttonsLayout">
+                <BoxView Style="{StaticResource Separator}"/>
                 <StackLayout Orientation="Vertical" HorizontalOptions="CenterAndExpand" Margin="16, 32, 16, 32">
                     <Button x:Name="scanButton" Text="START SCANNING" CornerRadius="10" Padding="24, 16" BackgroundColor="#c8193c" TextColor="White"/>
                 </StackLayout>
-            <BoxView Style="{StaticResource Separator}"/>
+                <BoxView Style="{StaticResource Separator}"/>
+            </StackLayout>
+            <StackLayout x:Name="resultsPreviewLayout" BackgroundColor="#d2d2d2" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
+                <Label Text="Results Preview (LIVE)" FontAttributes="Bold" Margin="16,16,16,16" FontSize="16" TextColor="Black"/>
+                <Label x:Name="resultsLabel" Margin="16,0,16,0" HorizontalTextAlignment="Start" TextColor="Black" FontSize="16"/>
+            </StackLayout>
         </StackLayout>
-        <StackLayout x:Name="resultsPreviewLayout" BackgroundColor="#d2d2d2" VerticalOptions="FillAndExpand" HorizontalOptions="FillAndExpand">
-            <Label Text="Results Preview (LIVE)" FontAttributes="Bold" Margin="16,16,16,16" FontSize="16" TextColor="Black"/>
-            <Label x:Name="resultsLabel" Margin="16,0,16,0" HorizontalTextAlignment="Start" TextColor="Black" FontSize="16"/>
-        </StackLayout>
-    </StackLayout>
-
+    </ScrollView>
 </ContentPage>

--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/MainPage.xaml.cs
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/MainPage.xaml.cs
@@ -10,9 +10,11 @@ namespace Native.Renderers.Example.Forms
     public partial class MainPage : ContentPage
     {
         private bool isDetectionOn;
-        private bool IsDetectionOn {
+        private bool IsDetectionOn
+        {
             get => isDetectionOn;
-            set {
+            set
+            {
                 isDetectionOn = value;
                 scanButton.Text = value ? "STOP SCANNING" : "START SCANNING";
                 RefreshCamera();
@@ -27,23 +29,12 @@ namespace Native.Renderers.Example.Forms
 
         private void SetupViews()
         {
-            cameraView.OnBarcodeScanResult = (result) =>
-            {
-                string text = "";
-                foreach (Barcode barcode in result.Barcodes) {
-                    text += string.Format("{0} ({1})\n", barcode.Text, barcode.Format.ToString().ToUpper());
-                }
-
-                Device.BeginInvokeOnMainThread(() =>
-                {
-                    resultsLabel.Text = text;
-                });
-            };
-
+            cameraView.OnBarcodeScanResult = HandleBarcodeScanningResult;
             cameraView.OverlayConfiguration = new SelectionOverlayConfiguration(
-                automaticSelectionEnabled: false, overlayFormat: OverlayFormat.Code,
+                automaticSelectionEnabled: true, overlayFormat: OverlayFormat.Code,
                 polygon: Color.Black, text: Color.Black, textContainer: Color.White,
                 highlightedPolygonColor: Color.Red, highlightedTextColor: Color.Red, highlightedTextContainerColor: Color.Black);
+            cameraView.ImageGenerationType = BarcodeImageGenerationType.CapturedImage;
         }
 
         protected override void OnAppearing()
@@ -57,7 +48,8 @@ namespace Native.Renderers.Example.Forms
             scanButton.Clicked += OnScanButtonPressed;
             infoButton.Clicked += OnInfoButtonPressed;
 
-            if (ScanbotSDKConfiguration.LICENSE_KEY.Equals("")) {
+            if (ScanbotSDKConfiguration.LICENSE_KEY.Equals(""))
+            {
                 ShowTrialLicenseAlert();
             }
         }
@@ -74,12 +66,15 @@ namespace Native.Renderers.Example.Forms
 
         private void OnScanButtonPressed(object sender, EventArgs e)
         {
-            if (!SBSDK.IsLicenseValid) {
+            if (!SBSDK.IsLicenseValid && !IsDetectionOn)
+            {
                 ShowExpiredLicenseAlert();
                 return;
             }
 
             IsDetectionOn = !IsDetectionOn;
+            cameraView.IsVisible = true;
+            cameraViewImage.IsVisible = false;
         }
 
         private void PauseCamera()
@@ -93,6 +88,7 @@ namespace Native.Renderers.Example.Forms
             if (IsDetectionOn)
             {
                 cameraView.StartDetection();
+                resultsLabel.Text = string.Empty;
             }
             else
             {
@@ -100,15 +96,18 @@ namespace Native.Renderers.Example.Forms
             }
         }
 
-        private void OnInfoButtonPressed(object sender, EventArgs e) {
+        private void OnInfoButtonPressed(object sender, EventArgs e)
+        {
             DisplayAlert("Info", SBSDK.IsLicenseValid ? "Your SDK License is valid." : "Your SDK License has expired.", "Close");
         }
 
-        private void ShowExpiredLicenseAlert() {
+        private void ShowExpiredLicenseAlert()
+        {
             DisplayAlert("Error", "Your SDK license has expired", "Close");
         }
 
-        private void ShowTrialLicenseAlert() {
+        private void ShowTrialLicenseAlert()
+        {
             DisplayAlert("Welcome", "You are using the Trial SDK License. The SDK will be active for one minute.", "Close");
         }
 
@@ -119,9 +118,30 @@ namespace Native.Renderers.Example.Forms
             var safeInsets = On<iOS>().SafeAreaInsets();
             safeInsets.Bottom = 0;
             Padding = safeInsets;
+        }
 
-            resultsPreviewLayout.BackgroundColor = Color.White;
-            buttonsLayout.IsVisible = false;
+        private void HandleBarcodeScanningResult(BarcodeScanningResult result)
+        {
+            string text = string.Empty;
+            Barcode barcodeItem = null;
+            foreach (Barcode barcode in result.Barcodes)
+            {
+                text += string.Format("{0} ({1})\n", barcode.Text, barcode.Format.ToString().ToUpper());
+                barcodeItem = barcode;
+            }
+
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                resultsLabel.Text = text;
+                if (cameraView.ImageGenerationType == BarcodeImageGenerationType.CapturedImage)
+                {
+                    IsDetectionOn = false;
+                    cameraView.IsVisible = false;
+                    cameraViewImage.IsVisible = true;
+                    cameraViewImage.Source = barcodeItem?.Image;
+                    cameraViewImage.Aspect = Aspect.AspectFit;
+                }
+            });
         }
     }
 }

--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/Views/BarcodeCameraView.cs
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/Views/BarcodeCameraView.cs
@@ -60,6 +60,7 @@ namespace Native.Renderers.Example.Forms.Views
         /// <summary>
         /// Specifies the way of barcode images generation or disables this generation at all.
         /// Use, if you want to receive a full sized image with barcodes.
+        /// iOS only.
         /// </summary>
         public BarcodeImageGenerationType ImageGenerationType { get; set; }
 

--- a/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/Views/BarcodeCameraView.cs
+++ b/Native.Renderers.Example.Forms/Native.Renderers.Example.Forms/Views/BarcodeCameraView.cs
@@ -58,6 +58,12 @@ namespace Native.Renderers.Example.Forms.Views
         public SelectionOverlayConfiguration OverlayConfiguration { get; set; }
 
         /// <summary>
+        /// Specifies the way of barcode images generation or disables this generation at all.
+        /// Use, if you want to receive a full sized image with barcodes.
+        /// </summary>
+        public BarcodeImageGenerationType ImageGenerationType { get; set; }
+
+        /// <summary>
         /// Flash enabled.
         /// </summary>
         public bool IsFlashEnabled { get; set; }


### PR DESCRIPTION
**Xamarin Forms - Native Renderer:**

- [x] Added the ImageGenerationType in common BarcodeCameraView. Handled it in the Common and Native sides.
- [x] Added button for Resuming-Pausing the Scanning in iOS platform.
- [x] iOS - Fixed the bug for iOS platform getting reinitialised multiple times when Layout Subviews is invoked. This fixed the background app freeze.